### PR TITLE
Expose internal `DynObjectStore` from `PyObjectStore` struct

### DIFF
--- a/object-store-internal/src/lib.rs
+++ b/object-store-internal/src/lib.rs
@@ -473,7 +473,7 @@ impl PyClientOptions {
 /// A generic object store interface for uniformly interacting with AWS S3, Google Cloud Storage,
 /// Azure Blob Storage and local files.
 pub struct PyObjectStore {
-    inner: Arc<DynObjectStore>,
+    pub inner: Arc<DynObjectStore>,
     rt: Arc<Runtime>,
     root_url: String,
     options: Option<HashMap<String, String>>,


### PR DESCRIPTION
In [`geoarrow-rs`](https://github.com/geoarrow/geoarrow-rs) I'm implementing parsers for geospatial file formats using object-store. I also have Python bindings, and it would be nice to reuse the builders in `object-store-python`, but I need direct access to the underlying `object-store` instance.

https://github.com/geoarrow/geoarrow-rs/pull/536 uses this PR on my branch and successfully reads a [FlatGeobuf](https://flatgeobuf.org/) file from S3.